### PR TITLE
Add CTD_SIMU_RAI (RAIR-Sim) to Applications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ project. They generally do one set of things well.
 * [Bistromath](https://bistromath.kegge13.nl/index.php?i=download.php) - Analyse 1D profiles from beam scanners.
 * [CERR](https://github.com/cerr/CERR) - A Computational Environment for Radiological Research
 * [Conquest](https://github.com/marcelvanherk/Conquest-DICOM-Server) - A full featured DICOM server
+* [CTD_SIMU_RAI](https://github.com/MarieFG49/CTD_SIMU_RAI) - RAIR-Sim, a compartmental simulator of the therapeutic response to radioactive iodine therapy in metastatic thyroid cancer, letting clinicians explore how session count, interval and administered activity affect the simulated thyroglobulin trajectory.
 * [ctqa](https://github.com/Brikwerk/ctqa) - This utility aims to perform automated QA testing on CT machines for technologists.
 * [ctqa-cp](https://github.com/medicalphysics/ctqa-cp) - (**Appears deprecated**) Analysis tool for CT images of the CatPhan phantom.
 * [DICOMautomaton](https://github.com/hdclark/DICOMautomaton) - DICOMautomaton is a multipurpose tool for analyzing medical physics data with a focus on automation.


### PR DESCRIPTION
RAIR-Sim is a MATLAB compartmental simulator of the therapeutic response to radioactive iodine (RAI) therapy in metastatic thyroid cancer. Three coupled ODEs (administered activity, tumour cell number, thyroglobulin biomarker) are solved in closed form fraction by fraction, so a clinician can vary the number of sessions, the interval between them and the administered activity, and read the effect on the simulated biomarker trajectory for both RAI-responding and RAI-refractory virtual patients. Model parameters are calibrated on a patient cohort.

- Repository: https://github.com/MarieFG49/CTD_SIMU_RAI
- MIT-licensed, documented, with CITATION.cff and a companion peer-reviewed paper.
- Added alphabetically to Applications, between Conquest and ctqa.

Disclosure: I am a co-author of the software (second author in its CITATION.cff); the repository is maintained by Marie Fusella Giuntini, who is aware of and supports this submission.